### PR TITLE
Add some fwb stubs from Oplus

### DIFF
--- a/core/java/com/oplus/theme/OplusThemeUtil.java
+++ b/core/java/com/oplus/theme/OplusThemeUtil.java
@@ -1,0 +1,9 @@
+package com.oplus.theme;
+
+import android.compat.annotation.UnsupportedAppUsage;
+
+public class OplusThemeUtil {
+    /** @hide */
+    @UnsupportedAppUsage
+    public static String CUSTOM_THEME_PATH = "/data/theme/com.oplus.camera";
+}

--- a/core/java/com/oplus/util/OplusTypeCastingHelper.java
+++ b/core/java/com/oplus/util/OplusTypeCastingHelper.java
@@ -1,0 +1,3 @@
+package com.oplus.util;
+
+public final class OplusTypeCastingHelper { }


### PR DESCRIPTION
This fixes Realme Link crash issue

Realme link tries to use reflection api for some oplus methods. Normally the are not presents if it is not oppo phone. They catch exception and all work fine, but on oplus/realme phones with imported oplus fwk for camera this doesn't work because we have these methods in separate boot jar and got denial from system on these hidden api methods. So, just move this harmless crap to FWB and annotate it properly.

Change-Id: I5ffecc9be52505371400b0b976c5f14e66bd853d